### PR TITLE
Integrate vision OI to CameraVision app and implement roborio pan/tilt servo control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,12 @@ deploy {
 // Set this to true to enable desktop support.
 def includeDesktopSupport = false
 
-// Maven central needed for JUnit
 repositories {
+    // Maven central needed for JUnit
     mavenCentral()
+    // Repositories needed for jitpack to get spartanlib
+    jcenter()
+    maven { url "https://jitpack.io" }
 }
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
@@ -50,6 +53,7 @@ dependencies {
 
     compile wpi.deps.wpilib()
     compile wpi.deps.vendor.java()
+    compile 'com.github.team997coders:SpartanLib:0.0.2-rc1'
     nativeZip wpi.deps.vendor.jni(wpi.platforms.roborio)
     nativeDesktopZip wpi.deps.vendor.jni(wpi.platforms.desktop)
     testCompile 'junit:junit:4.12'

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -5,6 +5,16 @@ import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import frc.robot.commands.FollowLine;
 import frc.robot.commands.DeployLandingGear;
 import frc.robot.commands.RetractLandingGear;
+import frc.robot.commands.VisionPressA;
+import frc.robot.commands.VisionPressB;
+import frc.robot.commands.VisionPressLeftShoulder;
+import frc.robot.commands.VisionPressLeftThumbstick;
+import frc.robot.commands.VisionPressLeftTrigger;
+import frc.robot.commands.VisionPressRightShoulder;
+import frc.robot.commands.VisionPressRightThumbstick;
+import frc.robot.commands.VisionPressRightTrigger;
+import frc.robot.commands.VisionPressX;
+import frc.robot.commands.VisionPressY;
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -16,9 +26,20 @@ public class OI {
   private JoystickButton deployLandingGear;
   private JoystickButton retractLandingGear;
   private JoystickButton followLine;
+  private JoystickButton visionButtonA;
+  private JoystickButton visionButtonB;
+  private JoystickButton visionButtonX;
+  private JoystickButton visionButtonY;
+  private JoystickButton visionButtonLeftShoulder;
+  private JoystickButton visionButtonRightShoulder;
+  private JoystickButton visionButtonLeftTrigger;
+  private JoystickButton visionButtonRightTrigger;
+  private JoystickButton visionButtonLeftThumbstick;
+  private JoystickButton visionButtonRightThumbstick;
 
   public OI() {
     gamepad1 = new Joystick(RobotMap.Ports.GamePad1);
+    gamepad2 = new Joystick(RobotMap.Ports.GamePad2);
 
     deployLandingGear = new JoystickButton(gamepad1, RobotMap.Ports.buttonB);
     deployLandingGear.whenPressed(new DeployLandingGear());
@@ -28,6 +49,36 @@ public class OI {
 
     followLine = new JoystickButton(gamepad1, 1);
     followLine.whenPressed(new FollowLine());
+
+    visionButtonA = new JoystickButton(gamepad2, RobotMap.Ports.buttonA);
+    visionButtonA.whenPressed(new VisionPressA());
+
+    visionButtonB = new JoystickButton(gamepad2, RobotMap.Ports.buttonB);
+    visionButtonB.whenPressed(new VisionPressB());
+
+    visionButtonX = new JoystickButton(gamepad2, RobotMap.Ports.buttonX);
+    visionButtonX.whenPressed(new VisionPressX());
+
+    visionButtonY = new JoystickButton(gamepad2, RobotMap.Ports.buttonY);
+    visionButtonY.whenPressed(new VisionPressY());
+
+    visionButtonLeftThumbstick = new JoystickButton(gamepad2, RobotMap.Ports.buttonLeftThumbstick);
+    visionButtonLeftThumbstick.whenPressed(new VisionPressLeftThumbstick());
+
+    visionButtonRightThumbstick = new JoystickButton(gamepad2, RobotMap.Ports.buttonRightThumbstick);
+    visionButtonRightThumbstick.whenPressed(new VisionPressRightThumbstick());
+
+    visionButtonLeftShoulder = new JoystickButton(gamepad2, RobotMap.Ports.buttonLeftShoulder);
+    visionButtonLeftShoulder.whenPressed(new VisionPressLeftShoulder());
+
+    visionButtonRightShoulder = new JoystickButton(gamepad2, RobotMap.Ports.buttonRightShoulder);
+    visionButtonRightShoulder.whenPressed(new VisionPressRightShoulder());
+
+    visionButtonLeftTrigger = new JoystickButton(gamepad2, RobotMap.Ports.buttonLeftTrigger);
+    visionButtonLeftTrigger.whenPressed(new VisionPressLeftTrigger());
+
+    visionButtonRightTrigger = new JoystickButton(gamepad2, RobotMap.Ports.buttonRightTrigger);
+    visionButtonRightTrigger.whenPressed(new VisionPressRightTrigger());
   }
 
   public double getLeftYAxis() {
@@ -40,6 +91,17 @@ public class OI {
 
   public double getRightYAxis() {
     return bing(0.05, -gamepad1.getRawAxis(RobotMap.Ports.rightYAxis), -1, 1);
+  }
+
+  public int getVisionLeftYAxis() {
+    // TODO: Are these ports the same across joysticks?
+    // I also do not think this should be negated for pan/tilt servos.
+    return (int)Math.round(bing(0.05, gamepad2.getRawAxis(RobotMap.Ports.leftYAxis), -1, 1) * 100);
+  }
+
+  public int getVisionLeftXAxis() {
+    // TODO: Are these ports the same across joysticks?
+    return (int)Math.round(bing(0.05, gamepad2.getRawAxis(RobotMap.Ports.rightXAxis), -1, 1) * 100);
   }
 
   public double deadBand(double value, double dead) {
@@ -60,6 +122,17 @@ public class OI {
     }
   }
 
+  /**
+   * I really wish programmers would name methods descriptively so that I do
+   * not have to waste my time figuring out what things like "bing" and "stuff" do!
+   * I am guessing that this does good "stuff" to my joystick. CCB.
+   * 
+   * @param dead
+   * @param val
+   * @param min
+   * @param max
+   * @return    I wish I knew
+   */
   public double bing(double dead, double val, double min, double max) {
     return clamp(min, max, deadBand(val, dead));
   }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -15,10 +15,11 @@ import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.commands.*;
+import frc.robot.subsystems.CameraMount;
 import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.LiftGear;
 import frc.robot.subsystems.LineFollowing;
-import frc.robot.vision.CameraVisionClient;
+import frc.robot.vision.cameravisionclient.CameraVisionClient;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -34,6 +35,7 @@ public class Robot extends TimedRobot {
   public static LiftGear liftGear;
   public static DriveTrain driveTrain;
   public static LineFollowing lineFollowing;
+  public static CameraMount cameraMount;
   // Note this could be null and because we continue to wire these up
   // in this manner, guards will have to be put around all accesses.
   // Otherwise null pointer exceptions will drive you crazy, in the case
@@ -59,6 +61,7 @@ public class Robot extends TimedRobot {
     liftGear = new LiftGear();
     driveTrain = new DriveTrain();
     lineFollowing = new LineFollowing();
+    cameraMount = new CameraMount(0, 120, 10, 170);
 
     // Connect to remote vision subsystem
     try {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -37,16 +37,18 @@ public class Robot extends TimedRobot {
   public static LineFollowing lineFollowing;
   public static CameraMount cameraMount;
   // Note this could be null and because we continue to wire these up
-  // in this manner, guards will have to be put around all accesses.
+  // in this manner (statics), guards will have to be put around all accesses.
   // Otherwise null pointer exceptions will drive you crazy, in the case
   // we do not connect to the Pi for some reason.
   public static CameraVisionClient cameraVisionClient;
+  public PanTiltCamera panTiltCamera;
 
   
   Command autonomousCommand;
   SendableChooser<Command> chooser = new SendableChooser<>();
 
   public Robot(DriveTrain a, LineFollowing b) {
+    super();
     driveTrain = a;
     lineFollowing = b;
   }
@@ -74,7 +76,14 @@ public class Robot extends TimedRobot {
     }
 
     oi = new OI();
-    
+
+    // Because there is no hardware subsystem directly hooked up
+    // to this command (it is a proxy for calling CameraVision on Pi)
+    // there is not default command to keep this active. So manually start
+    // here...
+    panTiltCamera = new PanTiltCamera();
+    panTiltCamera.start();
+
     chooser.setDefaultOption("Do Nothing", new AutoDoNothing());
     // chooser.addOption("My Auto", new MyAutoCommand());
     SmartDashboard.putData("Auto mode", chooser);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,8 @@
 
 package frc.robot;
 
+import java.io.IOException;
+
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
@@ -14,9 +16,9 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.commands.*;
 import frc.robot.subsystems.DriveTrain;
-import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.LiftGear;
 import frc.robot.subsystems.LineFollowing;
+import frc.robot.vision.CameraVisionClient;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -32,6 +34,11 @@ public class Robot extends TimedRobot {
   public static LiftGear liftGear;
   public static DriveTrain driveTrain;
   public static LineFollowing lineFollowing;
+  // Note this could be null and because we continue to wire these up
+  // in this manner, guards will have to be put around all accesses.
+  // Otherwise null pointer exceptions will drive you crazy, in the case
+  // we do not connect to the Pi for some reason.
+  public static CameraVisionClient cameraVisionClient;
 
   
   Command autonomousCommand;
@@ -52,6 +59,16 @@ public class Robot extends TimedRobot {
     liftGear = new LiftGear();
     driveTrain = new DriveTrain();
     lineFollowing = new LineFollowing();
+
+    // Connect to remote vision subsystem
+    try {
+      cameraVisionClient = new CameraVisionClient("10.9.97.6");
+    } catch (IOException e) {
+      // TODO: What is going to be the timing of roborio network availability, boot speed,
+      // and Pi boot speed? Need to test.
+      System.out.println("Can't connect to vision subsystem...do we need to put in a retry loop?");
+      System.out.println("Robot will proceed blind.");
+    }
 
     oi = new OI();
     

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -18,7 +18,17 @@ public class RobotMap {
     public static int
     
       GamePad1 = 0,
+      GamePad2 = 1,           // TODO: Need to check this
+      buttonA = 1,            // TODO: Need to check this
       buttonB = 2,
+      buttonX = 3,            // TODO: Need to check this
+      buttonY = 4,            // TODO: Need to check this
+      buttonLeftShoulder = 5,       // TODO: Need to check this
+      buttonRightShoulder = 6,      // TODO: Need to check this
+      buttonLeftThumbstick = 7,     // TODO: Need to check this
+      buttonRightThumbstick = 8,    // TODO: Need to check this
+      buttonLeftTrigger = 9,        // TODO: Need to check this
+      buttonRightTrigger = 10,      // TODO: Need to checl this
       buttonBack = 7,
 
       landingForward = 0,

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -51,7 +51,10 @@ public class RobotMap {
       linesensorright = 2,
       followLinebutton = 1,
 
-      ultrasonicsensor = 2;
+      ultrasonicsensor = 2,
+
+      panservo = 0,                 // TODO: Need to check this
+      tiltservo = 1;                // TODO: Need to check this
 
   }
 

--- a/src/main/java/frc/robot/commands/PanTiltCamera.java
+++ b/src/main/java/frc/robot/commands/PanTiltCamera.java
@@ -15,12 +15,16 @@ public class PanTiltCamera extends Command {
     // Pan/Tilt servos will be exclusively controlled by a sockets command processor.
   }
 
-  // Called just before this Command runs the first time
   @Override
   protected void initialize() {
   }
 
-  // Called repeatedly when this Command is scheduled to run
+  /**
+   * Simply forward pan/tilt commands (in otherwords, the current value
+   * of the vision operator interface joystick) to the CameraVisionClient.
+   * It will decide whether the servos will move and send commands back
+   * for the ProcessCameraMountCommands command to actualy move servos.
+   */
   @Override
   protected void execute() {
     if (Robot.cameraVisionClient != null) {

--- a/src/main/java/frc/robot/commands/PanTiltCamera.java
+++ b/src/main/java/frc/robot/commands/PanTiltCamera.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class PanTiltCamera extends Command {
+  public PanTiltCamera() {
+    // Pan/Tilt servos will be exclusively controlled by a sockets command processor.
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.slew(Robot.oi.getVisionLeftXAxis(), Robot.oi.getVisionLeftYAxis());
+    }
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return false;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+    end();
+  }
+}

--- a/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
+++ b/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
@@ -144,7 +144,12 @@ public class ProcessCameraMountCommands extends Command {
     cameraMountServer.acceptWhenAvailable();
   }
 
-  // Called repeatedly when this Command is scheduled to run
+  /**
+   * Each pump will check to see if a socket is available from a client
+   * connection attempt (presumable from the CameraVision application),
+   * and if so, will call the process method on the command processor
+   * to make the CameraMount servos move, if requested.
+   */
   @Override
   protected void execute() {
     // Trap IO errors...socket disconnects and such

--- a/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
+++ b/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
@@ -1,0 +1,103 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import org.team997coders.spartanlib.commands.CenterCamera;
+import org.team997coders.spartanlib.commands.SlewCamera;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.vision.cameramountserver.CameraMountServer;
+import frc.robot.vision.cameramountserver.CommandProcessor;
+import frc.robot.vision.cameramountserver.CommandProcessorValueBuilder;
+import frc.robot.vision.cameramountserver.JoystickValueProvider;
+
+public class ProcessCameraMountCommands extends Command {
+  private final CameraMountServer cameraMountServer;
+  private Socket socket;
+  private boolean socketHasError;
+  private CommandProcessor commandProcessor;
+  private JoystickValueProvider panValueProvider;
+  private JoystickValueProvider tiltValueProvider;
+
+  public ProcessCameraMountCommands(CameraMountServer cameraMountServer) throws IOException {
+    requires(Robot.cameraMount);
+    this.cameraMountServer = cameraMountServer;
+    // This socket will be listening for CameraMount commands
+    // from the CameraVision application.
+    socket = null;
+    socketHasError = false;
+    commandProcessor = null;
+    panValueProvider = null;
+    tiltValueProvider = null;
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    cameraMountServer.acceptWhenAvailable();
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+    try {
+      if (socket != null && socketHasError == false) {
+        commandProcessor.process();
+      } else if (cameraMountServer.isSocketAvailable()) {
+        socket = cameraMountServer.getSocket();
+        socketHasError = false;
+        panValueProvider = new JoystickValueProvider();
+        tiltValueProvider = new JoystickValueProvider();
+        commandProcessor = new CommandProcessor(
+          socket.getInputStream(), 
+          new PrintStream(socket.getOutputStream()), 
+          new CommandProcessorValueBuilder(), 
+          panValueProvider, 
+          tiltValueProvider, 
+          new CenterCamera(Robot.cameraMount), 
+          new SlewCamera(Robot.cameraMount, panValueProvider, tiltValueProvider),
+          Robot.cameraMount);
+      }
+    } catch (IOException e) {
+      socketHasError= true;
+    }
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return socketHasError;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+    if (socket != null) {
+      if (!socket.isClosed() && socket.isConnected()) {
+        try {
+          socket.close();
+        } catch (IOException e) {
+          System.out.println(e);
+        }
+      }
+    } 
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+    throw new RuntimeException("Only one command should be acting on this subsystem.");
+  }
+}

--- a/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
+++ b/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
@@ -17,32 +17,128 @@ import org.team997coders.spartanlib.commands.SlewCamera;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;
+import frc.robot.subsystems.CameraMount;
 import frc.robot.vision.cameramountserver.CameraMountServer;
 import frc.robot.vision.cameramountserver.CommandProcessor;
 import frc.robot.vision.cameramountserver.CommandProcessorValueBuilder;
 import frc.robot.vision.cameramountserver.JoystickValueProvider;
 
+/**
+ * This command will set up a socket server to read remote
+ * commands for panning/tilting the CameraMount. This is used
+ * by the CameraVision application to maintain control of the
+ * CameraMount pan/tilt servos.
+ */
 public class ProcessCameraMountCommands extends Command {
+  // Dependencies
   private final CameraMountServer cameraMountServer;
+  private final Thread cameraMountServerThread;
+  private final SlewCamera slewCamera;
+  private final CenterCamera centerCamera;
+  private final JoystickValueProvider panValueProvider;
+  private final JoystickValueProvider tiltValueProvider;
+  private final CameraMount cameraMount;
+  // This socket will be listening for CameraMount commands
+  // from the CameraVision application.
   private Socket socket;
+  // Flipped when socket disconnects occur
   private boolean socketHasError;
   private CommandProcessor commandProcessor;
-  private JoystickValueProvider panValueProvider;
-  private JoystickValueProvider tiltValueProvider;
 
-  public ProcessCameraMountCommands(CameraMountServer cameraMountServer) throws IOException {
+  /**
+   * This parameterless constructor will start a socket server
+   * listening for CameraMount commands on port 2223.
+   * 
+   * @throws IOException
+   */
+   public ProcessCameraMountCommands() throws IOException {
+    // TODO: Put in guards
+    this(2223);
+  }
+
+  /**
+   * Start a socket server listening for CameraMount commands
+   * on the specifed port.
+   * 
+   * @param port          The port to listen for remote client connects.
+   * @throws IOException
+   */
+  public ProcessCameraMountCommands(int port) throws IOException {
+    // TODO: Put in guards
+    this(new ServerSocket(port));
+  }
+
+  /**
+   * Start the CameraMountServer with the given ServerSocket.
+   * 
+   * @param serverSocket  The ServerSocket already bound to a port.
+   * @throws IOException
+   */
+  public ProcessCameraMountCommands(ServerSocket serverSocket) throws IOException {
+    // TODO: Put in guards
+    this(new CameraMountServer(serverSocket), new JoystickValueProvider(), new JoystickValueProvider());
+  }
+
+  /**
+   * Wire up a new thread to process the given CameraMountServer.
+   * 
+   * @param cameraMountServer The server providing sockets for connecting to clients.
+   * @param panValueProvider  A container to transport panning magnitude values from the operator interface.
+   * @param tiltValueProvider A container to transport tilting magnitude values from the operator interface.
+   * @throws IOException
+   */
+  public ProcessCameraMountCommands(CameraMountServer cameraMountServer, 
+      JoystickValueProvider panValueProvider, 
+      JoystickValueProvider tiltValueProvider) throws IOException {
+    // TODO: Put in guards
+    this(cameraMountServer, 
+      new Thread(cameraMountServer), 
+      new SlewCamera(Robot.cameraMount, panValueProvider, tiltValueProvider), 
+      new CenterCamera(Robot.cameraMount),
+      panValueProvider,
+      tiltValueProvider,
+      Robot.cameraMount);
+  }
+
+  /**
+   * Wire up defaults to begin the command processing sequence for this command by
+   * starting the given execution thread to process socket accept requests for the
+   * given CameraMountServer.
+   * 
+   * @param cameraMountServer         The server providing sockets for connecting to clients.
+   * @param cameraMountServerThread   The thread to execute the CameraMountServer.
+   * @param slewCamera                The command to slew the camera when panning or tilting commands are received.
+   * @param centerCamera              The command to center the camera when the center command is received.
+   * @param panValueProvider          A container to transport panning magnitude values from the operator interface.
+   * @param tiltValueProvider         A container to transport tilting magnitude values from the operator interface.
+   * @throws IOException
+   */
+  public ProcessCameraMountCommands(CameraMountServer cameraMountServer, 
+      Thread cameraMountServerThread, 
+      SlewCamera slewCamera, 
+      CenterCamera centerCamera,
+      JoystickValueProvider panValueProvider,
+      JoystickValueProvider tiltValueProvider,
+      CameraMount cameraMount) throws IOException {
+    // TODO: Put in guards
+    // The CameraMount subsystem will be used.
     requires(Robot.cameraMount);
+    // Wire up dependencies.
     this.cameraMountServer = cameraMountServer;
-    // This socket will be listening for CameraMount commands
-    // from the CameraVision application.
+    this.cameraMountServerThread = cameraMountServerThread;
+    this.slewCamera = slewCamera;
+    this.centerCamera = centerCamera;
+    this.panValueProvider = panValueProvider;
+    this.tiltValueProvider = tiltValueProvider;
+    this.cameraMount = cameraMount;
+    // Set default values
     socket = null;
     socketHasError = false;
     commandProcessor = null;
-    panValueProvider = null;
-    tiltValueProvider = null;
+    // Start up the CameraMountServer thread for providing sockets
+    this.cameraMountServerThread.start();
   }
 
-  // Called just before this Command runs the first time
   @Override
   protected void initialize() {
     cameraMountServer.acceptWhenAvailable();
@@ -51,36 +147,68 @@ public class ProcessCameraMountCommands extends Command {
   // Called repeatedly when this Command is scheduled to run
   @Override
   protected void execute() {
+    // Trap IO errors...socket disconnects and such
     try {
-      if (socket != null && socketHasError == false) {
+
+      // If we have a command processor and not encountered a socket error
+      if (commandProcessor != null && socketHasError == false) {
+
+        // then proceed to process commands from remote client
+        // (typically CameraVision application running on Pi)
         commandProcessor.process();
+
+      // If the socket server detects that a socket is available to read/write
+      // from (because a remote client is making a connection attempt...)
       } else if (cameraMountServer.isSocketAvailable()) {
+
+        System.out.println("ProcessCameraMountCommands getting socket...");
+
+        // Get the socket because we need the streams
         socket = cameraMountServer.getSocket();
+
+        // Reset the error flag so processing can take place
         socketHasError = false;
-        panValueProvider = new JoystickValueProvider();
-        tiltValueProvider = new JoystickValueProvider();
+
+        // Now wire up the command processor
         commandProcessor = new CommandProcessor(
           socket.getInputStream(), 
           new PrintStream(socket.getOutputStream()), 
           new CommandProcessorValueBuilder(), 
           panValueProvider, 
           tiltValueProvider, 
-          new CenterCamera(Robot.cameraMount), 
-          new SlewCamera(Robot.cameraMount, panValueProvider, tiltValueProvider),
-          Robot.cameraMount);
+          centerCamera, 
+          slewCamera,
+          cameraMount);
       }
     } catch (IOException e) {
-      socketHasError= true;
+      System.out.println(String.format("ProcessCameraMountCommands has socket error; reason=%s; continuing...", e));
+      // Socket has an error, probably because the client disconnected
+      // So set flag so we do not continue processing until another good
+      // socket is available.
+      socketHasError = true;
+      // Clean up but blow off errors. Just be a good citizen of resources.
+      try {
+        if (socket != null) {
+          socket.close();
+        }
+      } catch(IOException ioe){};
+      // Tell the socket server that we are ready for another socket when
+      // it has one.
+      cameraMountServer.acceptWhenAvailable();
     }
   }
 
-  // Make this return true when this Command no longer needs to run execute()
+  /**
+   * This command never finishes.
+   */
   @Override
   protected boolean isFinished() {
-    return socketHasError;
+    return false;
   }
 
-  // Called once after isFinished returns true
+  /**
+   * If this command ever finishes, clean up after ourselves.
+   */
   @Override
   protected void end() {
     if (socket != null) {
@@ -94,10 +222,15 @@ public class ProcessCameraMountCommands extends Command {
     } 
   }
 
-  // Called when another command which requires one or more of the same
-  // subsystems is scheduled to run
+  /**
+   * There should not be need for another command to act upon
+   * the pan/tilt servos as they are under the exclusive use
+   * of the CameraVision application. Note that CameraVision
+   * will forward operator control requests when the state of
+   * the HUD allows for it.
+   */
   @Override
   protected void interrupted() {
-    throw new RuntimeException("Only one command should be acting on this subsystem.");
+    throw new RuntimeException("Only the ProcessCameraMountCommand should be acting on this subsystem.");
   }
 }

--- a/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
+++ b/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
@@ -188,7 +188,7 @@ public class ProcessCameraMountCommands extends Command {
           cameraMount);
       }
     } catch (IOException e) {
-      System.out.println(String.format("ProcessCameraMountCommands has socket error; reason=%s; continuing...", e));
+      System.out.println(String.format("ProcessCameraMountCommands has socket error; reason=%s; continuing...", e.getMessage()));
       // Socket has an error, probably because the client disconnected
       // So set flag so we do not continue processing until another good
       // socket is available.

--- a/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
+++ b/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java
@@ -120,9 +120,11 @@ public class ProcessCameraMountCommands extends Command {
       JoystickValueProvider panValueProvider,
       JoystickValueProvider tiltValueProvider,
       CameraMount cameraMount) throws IOException {
+
     // TODO: Put in guards
+
     // The CameraMount subsystem will be used.
-    requires(Robot.cameraMount);
+    requires(cameraMount);
     // Wire up dependencies.
     this.cameraMountServer = cameraMountServer;
     this.cameraMountServerThread = cameraMountServerThread;

--- a/src/main/java/frc/robot/commands/VisionPressA.java
+++ b/src/main/java/frc/robot/commands/VisionPressA.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressA extends Command {
+  public VisionPressA() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressA();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressB.java
+++ b/src/main/java/frc/robot/commands/VisionPressB.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressB extends Command {
+  public VisionPressB() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressB();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressLeftShoulder.java
+++ b/src/main/java/frc/robot/commands/VisionPressLeftShoulder.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressLeftShoulder extends Command {
+  public VisionPressLeftShoulder() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressLeftShoulder();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressLeftThumbstick.java
+++ b/src/main/java/frc/robot/commands/VisionPressLeftThumbstick.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressLeftThumbstick extends Command {
+  public VisionPressLeftThumbstick() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressLeftThumbstick();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressLeftTrigger.java
+++ b/src/main/java/frc/robot/commands/VisionPressLeftTrigger.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressLeftTrigger extends Command {
+  public VisionPressLeftTrigger() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressLeftTrigger();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressRightShoulder.java
+++ b/src/main/java/frc/robot/commands/VisionPressRightShoulder.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressRightShoulder extends Command {
+  public VisionPressRightShoulder() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressRightShoulder();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressRightThumbstick.java
+++ b/src/main/java/frc/robot/commands/VisionPressRightThumbstick.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressRightThumbstick extends Command {
+  public VisionPressRightThumbstick() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressRightThumbstick();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressRightTrigger.java
+++ b/src/main/java/frc/robot/commands/VisionPressRightTrigger.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressRightTrigger extends Command {
+  public VisionPressRightTrigger() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressRightTrigger();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressX.java
+++ b/src/main/java/frc/robot/commands/VisionPressX.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressX extends Command {
+  public VisionPressX() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressX();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/commands/VisionPressY.java
+++ b/src/main/java/frc/robot/commands/VisionPressY.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class VisionPressY extends Command {
+  public VisionPressY() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    if (Robot.cameraVisionClient != null) {
+      Robot.cameraVisionClient.pressY();
+    }
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/subsystems/CameraMount.java
+++ b/src/main/java/frc/robot/subsystems/CameraMount.java
@@ -7,6 +7,8 @@
 
 package frc.robot.subsystems;
 
+import java.io.IOException;
+
 import org.team997coders.spartanlib.hardware.roborio.Servo;
 import org.team997coders.spartanlib.interfaces.IServo;
 
@@ -73,6 +75,10 @@ public class CameraMount extends org.team997coders.spartanlib.subsystems.CameraM
   @Override
   public void initDefaultCommand() {
     // Set the default command for a subsystem here.
-    //setDefaultCommand(new ProcessCameraMountCommands());
+    try {
+      setDefaultCommand(new ProcessCameraMountCommands());
+    } catch (IOException e) {
+      System.out.println(String.format("Cannot process default command for CameraMount. Pan/tilt will not work. Error=%s", e));
+    }
   } 
 }

--- a/src/main/java/frc/robot/subsystems/CameraMount.java
+++ b/src/main/java/frc/robot/subsystems/CameraMount.java
@@ -1,0 +1,78 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems;
+
+import org.team997coders.spartanlib.hardware.roborio.Servo;
+import org.team997coders.spartanlib.interfaces.IServo;
+
+import frc.robot.RobotMap;
+import frc.robot.commands.ProcessCameraMountCommands;
+
+/**
+ * A subsystem to define an automated camera mount that uses servos for panning and tilting.
+ */
+public class CameraMount extends org.team997coders.spartanlib.subsystems.CameraMount {
+
+  /**
+   * Convenience constructor to hard-wire CameraMount to Roborio servo implementation.
+   */
+  public CameraMount(int tiltLowerLimitInDegrees, 
+      int tiltUpperLimitInDegrees, 
+      int panLowerLimitInDegrees,
+      int panUpperLimitInDegrees) {
+    this(new Servo(RobotMap.Ports.panservo), 
+      new Servo(RobotMap.Ports.tiltservo, 544, 2250),
+      tiltLowerLimitInDegrees,
+      tiltUpperLimitInDegrees,
+      panLowerLimitInDegrees,
+      panUpperLimitInDegrees);
+  }
+
+  /**
+   * Constructor that sets travel limits of servos to 0..180
+   * 
+   * @param panServo    The pan servo
+   * @param tiltServo   The tilt servo
+   */
+  public CameraMount(IServo panServo, IServo tiltServo) {
+    this(panServo, tiltServo, 0, 180, 0, 180);
+  }
+
+  /**
+   * Constructor to set travel limits.
+   * 
+   * @param panServo
+   * @param tiltServo
+   * @param tiltLowerLimitInDegrees
+   * @param tiltUpperLimitInDegrees
+   * @param panLowerLimitInDegrees
+   * @param panUpperLimitInDegrees
+   */
+  public CameraMount(IServo panServo, 
+      IServo tiltServo, 
+      int tiltLowerLimitInDegrees, 
+      int tiltUpperLimitInDegrees, 
+      int panLowerLimitInDegrees,
+      int panUpperLimitInDegrees) {
+    super(panServo, 
+      tiltServo, 
+      tiltLowerLimitInDegrees, 
+      tiltUpperLimitInDegrees, 
+      panLowerLimitInDegrees, 
+      panUpperLimitInDegrees);
+  }
+
+  /**
+   * Set the default command to process commands sent from remote CameraVision application
+   */
+  @Override
+  public void initDefaultCommand() {
+    // Set the default command for a subsystem here.
+    //setDefaultCommand(new ProcessCameraMountCommands());
+  } 
+}

--- a/src/main/java/frc/robot/vision/CameraVisionClient.java
+++ b/src/main/java/frc/robot/vision/CameraVisionClient.java
@@ -1,0 +1,218 @@
+package frc.robot.vision;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * Class which sends commands to the CameraVision application over
+ * network sockets. All heads up display functionality is handled
+ * there and all control of pan/tilt servos are handled by a state
+ * machine within that application.
+ */
+public class CameraVisionClient implements Closeable {
+  private Socket socket;
+  private PrintWriter client;
+  private final String host;
+  private final int port;
+  private boolean lastPanWasZero;
+  private boolean lastTiltWasZero;
+  private boolean connected;
+
+  /**
+   * Constructor that assumes the client is running on localhost and 
+   * the default port (2222).
+   * @throws UnknownHostException
+   * @throws IOException
+   */
+  public CameraVisionClient() throws UnknownHostException, IOException {
+    this(null);
+  }
+
+  /**
+   * Constructor requiring a host name running the CameraVision application.
+   * Assume that the default port is used (2222).
+   * @param host                  The name of the host running the application.
+   * @throws UnknownHostException IP address cannot be found.
+   * @throws IOException          Thrown if...who knows.
+   */
+  public CameraVisionClient(String host) throws UnknownHostException, IOException {
+    this(host, 2222);
+  }
+
+  /**
+   * Constructor requiring a host name running the CameraVision application.
+   * Assume that the default port is used (2222).
+   * @param host                  The name of the host running the application.
+   * @param port                  The port that the application is listening for commands.
+   * @throws UnknownHostException IP address cannot be found.
+   * @throws IOException          Thrown if...who knows.
+   */
+  public CameraVisionClient(String host, int port) throws UnknownHostException, IOException {
+    this.host = host;
+    this.port = port;
+    connected = false;
+    // Socket to talk to the CameraVision application
+    this.socket = new Socket(host, port);
+    // Disable NAGLE algo so that sent packets are not held up.
+    // This seems to be disabled on the Windows loopback, so I do
+    // not see performance problems there but do when deploying
+    // the CameraVision app across the network.
+    this.socket.setTcpNoDelay(true);
+    // PrintWriter through which we will write commands to
+    this.client = new PrintWriter(socket.getOutputStream(), true);
+    lastPanWasZero = true;
+    lastTiltWasZero = true;
+    System.out.println("CameraVisionClient connected.");
+    connected = true;
+  }
+
+  /**
+   * Close all resources.
+   */
+  public void close() throws IOException {
+    socket.close();
+    connected = false;
+    System.out.println("CameraVisionClient disconnected.");
+  }
+
+  /**
+   * Wrap up PrintWriter printf to check for errors and reconnect to the socket.
+   * 
+   * @param format  The string format.
+   * @param args    Variable length argument list.
+   */
+  private void printf(String format, Object... args) {
+    // Try to print the command
+    client.printf(format, args);
+    // If it fails, then try to reconnect and print again.
+    if (client.checkError()) {
+      if (connected) {
+        System.out.println("CameraVisionClient disconnected.");
+        connected = false;
+      }
+      try {
+        lastPanWasZero = true;
+        lastTiltWasZero = true;
+        client.close();
+        socket.close();
+        // Socket to talk to the CameraVision application
+        socket = new Socket(host, port);
+        socket.setTcpNoDelay(true);
+        // PrintWriter through which we will write commands to
+        client = new PrintWriter(socket.getOutputStream(), true);
+        client.printf(format, args);
+        if (!client.checkError()) {
+          connected = true;
+          System.out.println("CameraVisionClient connected.");
+        }
+      } catch (Exception e) {
+        // do nothing
+      }
+    }
+  }
+
+  /**
+   * Slew (both pan and tilt) the camera with values between -100..100,
+   * which represents the percentage rate to slew to maximum.
+   * 
+   * @param panPct  Percentage of maximum rate to pan
+   * @param tiltPct Percentage of maximum rate to tilt
+   */
+  public void slew(int panPct, int tiltPct) {
+    // Keep from flooding pipe with zero pan commands
+    // Also treat -1..1 as zero to deal with rounding issues from joystick
+    if (panPct >= -3 && panPct <= 3) {
+      if (!lastPanWasZero) {
+        printf("%dp", 0);
+        lastPanWasZero = true;
+      }
+    } else {
+      printf("%dp", panPct);
+      lastPanWasZero = false;
+    }
+    // Keep from flooding pipe with zero tilt commands
+    // Also treat -1..1 as zero to deal with rounding issues from joystick
+    if (tiltPct >= -3 && tiltPct <= 3) {
+      if (!lastTiltWasZero) {
+        printf("%dt", 0);
+        lastTiltWasZero = true;
+      }
+    } else {
+      printf("%dt", tiltPct);
+      lastTiltWasZero = false;
+    }
+  }
+
+  /**
+   * Press left thumbstick button.
+   */
+  public void pressLeftThumbstick() {
+    printf("c");
+  }
+
+  /**
+   * Press right thumbstick button.
+   */
+  public void pressRightThumbstick() {
+    printf("d");
+  }
+
+  /**
+   * Press left shoulder button.
+   */
+  public void pressLeftShoulder() {
+    printf("e");
+  }
+
+  /**
+   * Press right shoulder button.
+   */
+  public void pressRightShoulder() {
+    printf("f");
+  }
+
+    /**
+   * Press left trigger button.
+   */
+  public void pressLeftTrigger() {
+    printf("g");
+  }
+
+  /**
+   * Press right trigger button.
+   */
+  public void pressRightTrigger() {
+    printf("h");
+  }
+
+  /**
+   * Press A.
+   */
+  public void pressA() {
+    printf("A");
+  }
+
+  /**
+   * Press B.
+   */
+  public void pressB() {
+    printf("B");
+  }
+
+  /**
+   * Press X.
+   */
+  public void pressX() {
+    printf("X");
+  }
+
+  /**
+   * Press Y.
+   */
+  public void pressY() {
+    printf("Y");
+  }
+}

--- a/src/main/java/frc/robot/vision/cameramountserver/CameraMountServer.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/CameraMountServer.java
@@ -7,7 +7,8 @@ import java.net.Socket;
 
 /**
  * This class processes one socket accept at a time in order
- * to provide streams for the command processor.
+ * to provide streams for the command processor. It presents
+ * these sockets to a consumer for their use.
  */
 public class CameraMountServer implements Runnable, Closeable {
   private final ServerSocket serverSocket;
@@ -21,10 +22,21 @@ public class CameraMountServer implements Runnable, Closeable {
     socketAvailable = false;
   }
 
+  /**
+   * Tests whether a socket is available for use.
+   * 
+   * @return  True if available.
+   */
   public boolean isSocketAvailable() {
     return socketAvailable;
   }
 
+  /**
+   * Tells the server that it is ok to accept
+   * another socket if one is available to accept.
+   * Sockets are only available to accept if a client
+   * is requesting to connect.
+   */
   public void acceptWhenAvailable() {
     accepting = true;
   }
@@ -41,6 +53,10 @@ public class CameraMountServer implements Runnable, Closeable {
     }
   }
 
+  /**
+   * Closes open resources. Try-with-resources will automatically call this
+   * method.
+   */
   public void close() {
     if (socket != null) {
       if (!socket.isClosed() && socket.isConnected()) {
@@ -54,12 +70,14 @@ public class CameraMountServer implements Runnable, Closeable {
     }
   }
 
+  /**
+   * Main entry point for a thread running this server.
+   */
   public void run() {
     while (!Thread.currentThread().isInterrupted()) {
-      // Get a connection socket so we can get the input stream
-      // Only one accept will be allowed at a time...
-
+      // Get a socket so we can get ultimately get the streams for command processing
       try {
+        // Only one accept will be allowed at a time...
         if (accepting) {
           accepting = false;
           System.out.println("CameraMountServer awaiting command connection...");
@@ -67,6 +85,8 @@ public class CameraMountServer implements Runnable, Closeable {
           // Disable NAGLE algo so that reply packets are not held up.
           socket.setTcpNoDelay(true);
           System.out.println("CameraMountServer command connection established...");
+          // Set our flag telling the consumer a socket is fired
+          // up and ready to go for command processing.
           socketAvailable = true;
         }
         // Don't spin the CPUs

--- a/src/main/java/frc/robot/vision/cameramountserver/CameraMountServer.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/CameraMountServer.java
@@ -1,0 +1,84 @@
+package frc.robot.vision.cameramountserver;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+/**
+ * This class processes one socket accept at a time in order
+ * to provide streams for the command processor.
+ */
+public class CameraMountServer implements Runnable, Closeable {
+  private final ServerSocket serverSocket;
+  private Socket socket;
+  private volatile boolean accepting;
+  private volatile boolean socketAvailable;
+
+  public CameraMountServer(ServerSocket serverSocket) {
+    this.serverSocket = serverSocket;
+    accepting = false;
+    socketAvailable = false;
+  }
+
+  public boolean isSocketAvailable() {
+    return socketAvailable;
+  }
+
+  public void acceptWhenAvailable() {
+    accepting = true;
+  }
+
+  /**
+   * Get a socket based on a connection attempt from the CameraVision application.
+   * @return  A socket ready for IO.
+   */
+  public Socket getSocket() {
+    if (socketAvailable) {
+      return socket;
+    } else {
+      throw new SocketUnavailableException();
+    }
+  }
+
+  public void close() {
+    if (socket != null) {
+      if (!socket.isClosed() && socket.isConnected()) {
+        try {
+          socket.close();
+        } catch (IOException e) {
+          e.printStackTrace();
+          System.out.println("Error closing socket.");
+        }
+      }
+    }
+  }
+
+  public void run() {
+    while (!Thread.currentThread().isInterrupted()) {
+      // Get a connection socket so we can get the input stream
+      // Only one accept will be allowed at a time...
+
+      try {
+        if (accepting) {
+          accepting = false;
+          System.out.println("CameraMountServer awaiting command connection...");
+          socket = serverSocket.accept();
+          // Disable NAGLE algo so that reply packets are not held up.
+          socket.setTcpNoDelay(true);
+          System.out.println("CameraMountServer command connection established...");
+          socketAvailable = true;
+        }
+        // Don't spin the CPUs
+        Thread.sleep(20);
+      } catch (IOException e) {
+        e.printStackTrace();
+        System.out.println("CameraMountServer command processor halted.");
+        // Exit the thread
+        break;          
+      } catch (InterruptedException e) {
+        Thread.interrupted();
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/vision/cameramountserver/CommandProcessor.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/CommandProcessor.java
@@ -1,0 +1,185 @@
+package frc.robot.vision.cameramountserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import org.team997coders.spartanlib.commands.SlewCamera;
+import org.team997coders.spartanlib.subsystems.CameraMount;
+import org.team997coders.spartanlib.commands.CenterCamera;
+
+/**
+ * This is a state machine to gather input from presumably
+ * a joystick and translate that input into commands that can
+ * operate the camera mount.
+ */
+public class CommandProcessor {
+  private final InputStream m_input;
+  private final PrintStream m_output;
+  private final CommandProcessorValueBuilder m_valueBuilder;
+  private final JoystickValueProvider m_panValueProvider;
+  private final JoystickValueProvider m_tiltValueProvider;
+  private final CenterCamera m_centerCamera;
+  private final SlewCamera m_slewCamera;
+  private final CameraMount m_cameraMount;
+
+  private boolean echo = false;
+
+  /**
+   * Constructor for the command processor
+   * 
+   * @param input               The input stream to read command characters from
+   * @param output              The output stream to write responses to
+   * @param valueBuilder        The value builder to collect command values
+   * @param panValueProvider    The pan value provider to give values to downstream commands
+   * @param tiltValueProvider   The tilt value provider to give values to downstream commands
+   * @param centerCamera        The center camera command to call when centering
+   * @param slewCamera          The slew camera command to call when slewing axis
+   */
+  public CommandProcessor(InputStream input, 
+      PrintStream output, 
+      CommandProcessorValueBuilder valueBuilder,
+      JoystickValueProvider panValueProvider,
+      JoystickValueProvider tiltValueProvider,
+      CenterCamera centerCamera,
+      SlewCamera slewCamera,
+      CameraMount cameraMount) {
+
+    // Keep references to dependencies
+    m_input = input;
+    m_output = output;
+    m_valueBuilder = valueBuilder;
+    m_panValueProvider = panValueProvider;
+    m_tiltValueProvider = tiltValueProvider;
+    m_centerCamera = centerCamera;
+    m_slewCamera = slewCamera;
+    m_cameraMount = cameraMount;
+
+    // Reset the value builder to make sure we are ready to build
+    m_valueBuilder.reset();
+
+    // Tell who ever is listening that we are ready
+    m_output.print("Ready");
+  }
+
+  /**
+   * Provide feedback to the listener that characters are being received
+   * and/or commands are being processed. If the echo command has not been
+   * received, then CRLF will not be sent between line breaks and input
+   * characters will not be echoed back.
+   */
+  private void acknowledge(char input, boolean commandPerformed) {
+    if (echo) {
+      m_output.print(input);
+      if (commandPerformed) {
+        m_output.println("");
+      }
+    }
+    if (commandPerformed) {
+      m_output.print("Ok");
+      if (echo) {
+        m_output.println("");
+      }
+    }
+  }
+
+  /**
+   * Reply back to the get angle command with the tilt
+   * and the pan angles (in that order). Replied as two
+   * hex strings delimited by a colon...yuck. Binary writing not available
+   * on PrintStream implementation.
+   * 
+   * These angles are from 0 to 180 degrees, subject to pan/tilt limitations.
+   * Center is 90 degrees.
+   */
+  private void replytoAngle(char input) throws IOException {
+    if (echo) {
+      m_output.println(input);
+    }
+    String reply = toHexStringPadded(m_cameraMount.getRoundedTiltAngleInDegrees()) + ":" + toHexStringPadded(m_cameraMount.getRoundedPanAngleInDegrees()); 
+    m_output.print(reply);
+    if (echo) {
+      m_output.println("");
+    }
+  }
+
+  private static String toHexStringPadded(int number) {
+    String toHex = Integer.toHexString(number);
+    if (toHex.length() == 0) {
+      return "00";
+    } else if (toHex.length() == 1) {
+      return "0" + toHex;
+    } else {
+      return toHex;
+    }
+  }
+
+  /**
+   * Process input characters and perform camera mount movement commands.<p>
+   * Commands are as follows:<p>
+   * <ul>
+   *   <li>e - Turn echo on/off (defaults to off). If on, this will echo all command characters
+   *           and send a CRLF once commands are executed</li>
+   *   <li>c - Center pan and tilt at 90 degrees
+   *   <li>a - Get tilt and pan angles (int that order) in degrees. Center is 90 degrees.
+   *   <li>p[-]nnn - Pan in a positive or negative direction at a speed given by the percentage of maximum
+   *   <li>t[-]nnn - Tilt in a positive or negative direction at a speed given by the percentage of maximum
+   * </ul>
+   * Responses are as follows (note no CRLF follows these unless echo is on):<p>
+   * <ul>
+   *   <li>Ready - Upon first connection to the serial port
+   *   <li>Ok - Sent in response to receiving a command
+   *   <li>[hex integer]:[hex integer] - Sent in response to the 'a' command
+   * </ul>
+   */
+  public void process() {
+    try {  
+      char input = (char) m_input.read();
+      switch(input) {
+        case '0': case '1': case '2': case '3': case '4':
+        case '5': case '6': case '7': case '8': case '9':
+          m_valueBuilder.addNumeral(input);
+          acknowledge(input, false);
+          break;
+        case '-':
+          m_valueBuilder.setNegative();
+          acknowledge(input, false);
+          break;
+        case 'p':
+          m_panValueProvider.setValue(m_valueBuilder.getValue());
+          m_slewCamera.start();
+          acknowledge(input, true);
+          m_valueBuilder.reset();
+          break;
+        case 't':
+          m_tiltValueProvider.setValue(m_valueBuilder.getValue());
+          m_slewCamera.start();
+          acknowledge(input, true);
+          m_valueBuilder.reset();
+          break;
+        case 'c':
+          m_centerCamera.start();
+          acknowledge(input, true);
+          m_valueBuilder.reset();
+          break;
+        case 'a':
+          replytoAngle(input);
+          m_valueBuilder.reset();
+          break;
+        case 'e':
+          echo = !echo;
+          acknowledge(input, true);
+          m_valueBuilder.reset();
+          break;
+        case 'r':
+          acknowledge(input, true);
+          m_valueBuilder.reset();
+          break;
+      }
+    } catch (Exception e) {
+      if (echo) {
+        System.err.println(e);
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/vision/cameramountserver/CommandProcessor.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/CommandProcessor.java
@@ -132,54 +132,48 @@ public class CommandProcessor {
    *   <li>[hex integer]:[hex integer] - Sent in response to the 'a' command
    * </ul>
    */
-  public void process() {
-    try {  
-      char input = (char) m_input.read();
-      switch(input) {
-        case '0': case '1': case '2': case '3': case '4':
-        case '5': case '6': case '7': case '8': case '9':
-          m_valueBuilder.addNumeral(input);
-          acknowledge(input, false);
-          break;
-        case '-':
-          m_valueBuilder.setNegative();
-          acknowledge(input, false);
-          break;
-        case 'p':
-          m_panValueProvider.setValue(m_valueBuilder.getValue());
-          m_slewCamera.start();
-          acknowledge(input, true);
-          m_valueBuilder.reset();
-          break;
-        case 't':
-          m_tiltValueProvider.setValue(m_valueBuilder.getValue());
-          m_slewCamera.start();
-          acknowledge(input, true);
-          m_valueBuilder.reset();
-          break;
-        case 'c':
-          m_centerCamera.start();
-          acknowledge(input, true);
-          m_valueBuilder.reset();
-          break;
-        case 'a':
-          replytoAngle(input);
-          m_valueBuilder.reset();
-          break;
-        case 'e':
-          echo = !echo;
-          acknowledge(input, true);
-          m_valueBuilder.reset();
-          break;
-        case 'r':
-          acknowledge(input, true);
-          m_valueBuilder.reset();
-          break;
-      }
-    } catch (Exception e) {
-      if (echo) {
-        System.err.println(e);
-      }
+  public void process() throws IOException {
+    char input = (char) m_input.read();
+    switch(input) {
+      case '0': case '1': case '2': case '3': case '4':
+      case '5': case '6': case '7': case '8': case '9':                 // Here comes a numeral for a value-based command
+        m_valueBuilder.addNumeral(input);
+        acknowledge(input, false);
+        break;
+      case '-':                                                         // Negative value coming your way
+        m_valueBuilder.setNegative();
+        acknowledge(input, false);
+        break;
+      case 'p':                                                         // Pan pan man
+        m_panValueProvider.setValue(m_valueBuilder.getValue());
+        m_slewCamera.start();
+        acknowledge(input, true);
+        m_valueBuilder.reset();
+        break;
+      case 't':                                                         // Tilt away
+        m_tiltValueProvider.setValue(m_valueBuilder.getValue());
+        m_slewCamera.start();
+        acknowledge(input, true);
+        m_valueBuilder.reset();
+        break;
+      case 'c':                                                         // Center yourself
+        m_centerCamera.start();
+        acknowledge(input, true);
+        m_valueBuilder.reset();
+        break;
+      case 'a':                                                         // Give me my angles
+        replytoAngle(input);
+        m_valueBuilder.reset();
+        break;
+      case 'e':                                                         // Echo commands back (for the telnet user)
+        echo = !echo;
+        acknowledge(input, true);
+        m_valueBuilder.reset();
+        break;
+      case 'r':                                                         // Ready tickler
+        acknowledge(input, true);
+        m_valueBuilder.reset();
+        break;
     }
   }
 }

--- a/src/main/java/frc/robot/vision/cameramountserver/CommandProcessorValueBuilder.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/CommandProcessorValueBuilder.java
@@ -1,0 +1,30 @@
+package frc.robot.vision.cameramountserver;
+/**
+ * This class provides a convenience wrapper for building numbers
+ * being entered from the serial command interface.
+ */
+public class CommandProcessorValueBuilder {
+  private int percentage = 0;
+  private boolean negation = false;
+
+  public double getValue() {
+    return negation ? percentage * -1 / 100.0 : percentage / 100.0;
+  }
+
+  public void setPositive() {
+    negation = false;
+  }
+
+  public void setNegative() {
+    negation = true;
+  }
+
+  public void reset() {
+    negation = false;
+    percentage = 0;
+  }
+
+  public void addNumeral(char numeral) {
+    percentage = (percentage * 10) + (numeral - '0');
+  }
+}

--- a/src/main/java/frc/robot/vision/cameramountserver/JoystickValueProvider.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/JoystickValueProvider.java
@@ -1,0 +1,22 @@
+package frc.robot.vision.cameramountserver;
+
+import org.team997coders.spartanlib.interfaces.IJoystickValueProvider;
+
+/**
+ * Implementation of the IJoystickValueProvider interface to simply
+ * provide a stored double value.
+ */
+public class JoystickValueProvider implements IJoystickValueProvider {
+  private double m_value = 0;
+
+  public JoystickValueProvider() {
+  }
+
+  public double getValue() {
+    return m_value;
+  }
+
+  public void setValue(double value) {
+    m_value = value;
+  }
+}

--- a/src/main/java/frc/robot/vision/cameramountserver/SocketUnavailableException.java
+++ b/src/main/java/frc/robot/vision/cameramountserver/SocketUnavailableException.java
@@ -1,0 +1,18 @@
+package frc.robot.vision.cameramountserver;
+
+/**
+ * Custom exception to indicate that a target is not expected
+ * where it should be.
+ */
+public class SocketUnavailableException extends RuntimeException {
+  public SocketUnavailableException () {}
+  public SocketUnavailableException (String message) {
+    super (message);
+  }
+  public SocketUnavailableException (Throwable cause) {
+    super (cause);
+  }
+  public SocketUnavailableException (String message, Throwable cause) {
+    super (message, cause);
+  }
+}

--- a/src/main/java/frc/robot/vision/cameravisionclient/CameraVisionClient.java
+++ b/src/main/java/frc/robot/vision/cameravisionclient/CameraVisionClient.java
@@ -1,4 +1,4 @@
-package frc.robot.vision;
+package frc.robot.vision.cameravisionclient;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/src/main/java/frc/robot/vision/cameravisionclient/CameraVisionClient.java
+++ b/src/main/java/frc/robot/vision/cameravisionclient/CameraVisionClient.java
@@ -109,7 +109,7 @@ public class CameraVisionClient implements Closeable {
           System.out.println("CameraVisionClient connected.");
         }
       } catch (Exception e) {
-        // do nothing
+        System.out.println("CameraVisionClient not connected.");
       }
     }
   }

--- a/src/test/java/frc/robot/commands/ProcessCameraMountCommandsUnitTest.java
+++ b/src/test/java/frc/robot/commands/ProcessCameraMountCommandsUnitTest.java
@@ -1,0 +1,125 @@
+package frc.robot.commands;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+import org.junit.Test;
+import org.team997coders.spartanlib.commands.CenterCamera;
+import org.team997coders.spartanlib.commands.SlewCamera;
+
+import frc.robot.subsystems.CameraMount;
+import frc.robot.vision.cameramountserver.CameraMountServer;
+import frc.robot.vision.cameramountserver.JoystickValueProvider;
+
+public class ProcessCameraMountCommandsUnitTest {
+  @Test
+  public void itProcessesCommands() throws IOException, InterruptedException {
+    // Assemble (and mock the world!)
+    CameraMountServer cameraMountServerMock = mock(CameraMountServer.class);
+    Socket socketMock = mock(Socket.class);
+    InputStream inputStreamMock = mock(InputStream.class);
+    OutputStream outputStreamMock = mock(OutputStream.class);
+    when(socketMock.getInputStream()).thenReturn(inputStreamMock);
+    when(socketMock.getOutputStream()).thenReturn(outputStreamMock);
+    when(cameraMountServerMock.getSocket()).thenReturn(socketMock);
+    when(cameraMountServerMock.isSocketAvailable()).thenReturn(true);
+    SlewCamera slewCameraMock = mock(SlewCamera.class);
+    CenterCamera centerCameraMock = mock(CenterCamera.class);
+    JoystickValueProvider panValueProviderMock = mock(JoystickValueProvider.class);
+    JoystickValueProvider tiltValueProviderMock = mock(JoystickValueProvider.class);
+    CameraMount cameraMountMock = mock(CameraMount.class);
+    Thread cameraMountServerThread = new Thread(cameraMountServerMock);
+
+    ProcessCameraMountCommands processCameraMountCommands = new ProcessCameraMountCommands(cameraMountServerMock, 
+      cameraMountServerThread, 
+      slewCameraMock, 
+      centerCameraMock, 
+      panValueProviderMock, 
+      tiltValueProviderMock, 
+      cameraMountMock);
+
+    // Act
+    // Give CameraMountServer a moment to get its ducks in a row
+    Thread.sleep(50);
+    processCameraMountCommands.execute();
+    // Pump twice as first iteration gets command processor wired up
+    processCameraMountCommands.execute();
+
+    // Assert
+    // Eventually, the input stream should have been read
+    // for commands being sent from a client
+    verify(inputStreamMock, atLeast(1)).read();
+  }
+
+  @Test
+  public void itRequestsANewSocketWhenExistingSocketGoesBellyUp() throws IOException, InterruptedException {
+    // Assemble (and mock the world!)
+    CameraMountServer cameraMountServerMock = mock(CameraMountServer.class);
+    Socket socketMock = mock(Socket.class);
+    OutputStream outputStreamMock = mock(OutputStream.class);
+    // Make inputStream barf
+    when(socketMock.getInputStream()).thenThrow(IOException.class);
+    when(socketMock.getOutputStream()).thenReturn(outputStreamMock);
+    when(cameraMountServerMock.getSocket()).thenReturn(socketMock);
+    when(cameraMountServerMock.isSocketAvailable()).thenReturn(true);
+    SlewCamera slewCameraMock = mock(SlewCamera.class);
+    CenterCamera centerCameraMock = mock(CenterCamera.class);
+    JoystickValueProvider panValueProviderMock = mock(JoystickValueProvider.class);
+    JoystickValueProvider tiltValueProviderMock = mock(JoystickValueProvider.class);
+    CameraMount cameraMountMock = mock(CameraMount.class);
+    Thread cameraMountServerThread = new Thread(cameraMountServerMock);
+
+    ProcessCameraMountCommands processCameraMountCommands = new ProcessCameraMountCommands(cameraMountServerMock, 
+      cameraMountServerThread, 
+      slewCameraMock, 
+      centerCameraMock, 
+      panValueProviderMock, 
+      tiltValueProviderMock, 
+      cameraMountMock);
+
+    // Act
+    // Give CameraMountServer a moment to get its ducks in a row
+    Thread.sleep(50);
+    processCameraMountCommands.execute();
+
+    // Assert
+    verify(cameraMountServerMock, times(1)).acceptWhenAvailable();
+  }
+
+  @Test
+  public void itInitializesTheServerToAcceptSockets() throws IOException, InterruptedException {
+    // Assemble (and mock the world!)
+    CameraMountServer cameraMountServerMock = mock(CameraMountServer.class);
+    Socket socketMock = mock(Socket.class);
+    SlewCamera slewCameraMock = mock(SlewCamera.class);
+    CenterCamera centerCameraMock = mock(CenterCamera.class);
+    JoystickValueProvider panValueProviderMock = mock(JoystickValueProvider.class);
+    JoystickValueProvider tiltValueProviderMock = mock(JoystickValueProvider.class);
+    CameraMount cameraMountMock = mock(CameraMount.class);
+    Thread cameraMountServerThread = new Thread(cameraMountServerMock);
+
+    ProcessCameraMountCommands processCameraMountCommands = new ProcessCameraMountCommands(cameraMountServerMock, 
+      cameraMountServerThread, 
+      slewCameraMock, 
+      centerCameraMock, 
+      panValueProviderMock, 
+      tiltValueProviderMock, 
+      cameraMountMock);
+
+    // Act
+    processCameraMountCommands.initialize();
+
+    // Assert
+    // Eventually, the input stream should have been read
+    // for commands being sent from a client
+    verify(cameraMountServerMock, atLeast(1)).acceptWhenAvailable();
+  }
+}

--- a/src/test/java/frc/robot/vision/cameramountserver/CameraMountServerUnitTest.java
+++ b/src/test/java/frc/robot/vision/cameramountserver/CameraMountServerUnitTest.java
@@ -1,0 +1,135 @@
+package frc.robot.vision.cameramountserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import org.junit.Test;
+
+public class CameraMountServerUnitTest {
+
+  @Test(expected = SocketUnavailableException.class)
+  public void itComplainsWhenGettingASocketWhenNoneAvailable() {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+
+    // Act
+    cameraMountServer.getSocket();
+
+    // Assert
+  }
+
+  @Test
+  public void thereIsNoSocket() {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+
+    // Act
+
+    // Assert
+    assertEquals(false, cameraMountServer.isSocketAvailable());
+  }
+
+  @Test
+  public void thereIsASocket() throws InterruptedException, IOException {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    Socket socketMock = mock(Socket.class);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+    // This makes a mock socket immediately available
+    when(serverSocketMock.accept()).thenReturn(socketMock);
+    // Without running a real thread, run() will run forever, hanging the test
+    Thread thread = new Thread(cameraMountServer);
+    thread.start();
+
+    // Act
+    // Wait for thread to run a bit
+    Thread.sleep(50);
+    // Now allow server to accept a socket
+    cameraMountServer.acceptWhenAvailable();
+    // Wait for thread to digest state change
+    Thread.sleep(50);
+
+    // Assert
+    assertEquals(true, cameraMountServer.isSocketAvailable());
+  }
+
+  @Test
+  public void theServerWillStop() throws InterruptedException {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+    Thread thread = new Thread(cameraMountServer);
+    thread.start();
+
+    // Act
+    // Wait for thread to run a bit
+    Thread.sleep(50);
+    cameraMountServer.stop();
+    // Wait for thread to digest state change
+    Thread.sleep(50);
+
+    // Assert
+    assertEquals(false, thread.isAlive());
+  }
+
+  @Test
+  public void itServesUpASocket() throws IOException, InterruptedException {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    Socket socketMock = mock(Socket.class);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+    // This makes a mock socket immediately available
+    when(serverSocketMock.accept()).thenReturn(socketMock);
+    // Without running a real thread, run() will run forever, hanging the test
+    Thread thread = new Thread(cameraMountServer);
+    thread.start();
+
+    // Act
+    // Wait for thread to run a bit
+    Thread.sleep(50);
+    // Now allow server to accept a socket
+    cameraMountServer.acceptWhenAvailable();
+    // Wait for thread to digest state change
+    Thread.sleep(50);
+
+    // Assert
+    assertEquals(socketMock, cameraMountServer.getSocket());
+  }
+
+  @Test
+  public void itCleansUpAfterItself() throws IOException, InterruptedException {
+    // Assemble
+    ServerSocket serverSocketMock = mock(ServerSocket.class);
+    Socket socketMock = mock(Socket.class);
+    when(socketMock.isClosed()).thenReturn(false);
+    when(socketMock.isConnected()).thenReturn(true);
+    CameraMountServer cameraMountServer = new CameraMountServer(serverSocketMock);
+    // This makes a mock socket immediately available
+    when(serverSocketMock.accept()).thenReturn(socketMock);
+    // Without running a real thread, run() will run forever, hanging the test
+    Thread thread = new Thread(cameraMountServer);
+    thread.start();
+
+    // Act
+    // Wait for thread to run a bit
+    Thread.sleep(50);
+    // Now allow server to accept a socket
+    cameraMountServer.acceptWhenAvailable();
+    // Wait for thread to digest state change
+    Thread.sleep(50);
+    // Simulate a try-with-resources close
+    cameraMountServer.close();
+
+    // Assert
+    verify(socketMock, times(1)).close();
+  }
+}

--- a/src/test/java/frc/robot/vision/cameramountserver/CameraMountServerUnitTest.java
+++ b/src/test/java/frc/robot/vision/cameramountserver/CameraMountServerUnitTest.java
@@ -52,11 +52,11 @@ public class CameraMountServerUnitTest {
 
     // Act
     // Wait for thread to run a bit
-    Thread.sleep(50);
+    Thread.sleep(100);
     // Now allow server to accept a socket
     cameraMountServer.acceptWhenAvailable();
     // Wait for thread to digest state change
-    Thread.sleep(50);
+    Thread.sleep(100);
 
     // Assert
     assertEquals(true, cameraMountServer.isSocketAvailable());
@@ -72,10 +72,10 @@ public class CameraMountServerUnitTest {
 
     // Act
     // Wait for thread to run a bit
-    Thread.sleep(50);
+    Thread.sleep(100);
     cameraMountServer.stop();
     // Wait for thread to digest state change
-    Thread.sleep(50);
+    Thread.sleep(100);
 
     // Assert
     assertEquals(false, thread.isAlive());
@@ -95,11 +95,11 @@ public class CameraMountServerUnitTest {
 
     // Act
     // Wait for thread to run a bit
-    Thread.sleep(50);
+    Thread.sleep(100);
     // Now allow server to accept a socket
     cameraMountServer.acceptWhenAvailable();
     // Wait for thread to digest state change
-    Thread.sleep(50);
+    Thread.sleep(100);
 
     // Assert
     assertEquals(socketMock, cameraMountServer.getSocket());
@@ -121,11 +121,11 @@ public class CameraMountServerUnitTest {
 
     // Act
     // Wait for thread to run a bit
-    Thread.sleep(50);
+    Thread.sleep(100);
     // Now allow server to accept a socket
     cameraMountServer.acceptWhenAvailable();
     // Wait for thread to digest state change
-    Thread.sleep(50);
+    Thread.sleep(100);
     // Simulate a try-with-resources close
     cameraMountServer.close();
 


### PR DESCRIPTION
This change hooks up gamepad2 to forward operator interface activity (left joystick movement and button presses) to the [CameraVision](https://github.com/Team997Coders/2019DSHatchFindingVision/tree/master/CameraVision) application running on the Pi. It does this over network sockets via a custom protocol that was tested using the [CameraVisionJoystickDriver](https://github.com/Team997Coders/CameraVisionJoystickDriver) project. I took the client code from that project and wired it up to the robot program OI.

I do it this way, instead of direct operator control over the pan/tilt servos, because the CameraVision application implements a state machine for the heads up display. Sometimes the operator has direct control over the servos, if they are in the right mode, and other times not. The robot program does not have to know or care about the modes...it just dumbly sends commands to CameraVision and lets it figure out what to do.

CameraVision then, in turn, needs to send servo movement commands back to the roborio, whether CameraVision is controlling camera movement autonomously, or whether it is simply forwarding operator commands sent to it back to the roborio because CameraVision is in target acquisition mode.

To do this, the robot program implements a [ProcessCameraMountCommands](https://github.com/Team997Coders/2019DeepSpace/blob/vision/src/main/java/frc/robot/commands/ProcessCameraMountCommands.java) wpilib command. This command listens to a custom protocol defined in [CommandProcessor.java](https://github.com/Team997Coders/2019DeepSpace/blob/vision/src/main/java/frc/robot/vision/cameramountserver/CommandProcessor.java), again using sockets, tested using the [MiniPanTiltTeensy](https://github.com/Team997Coders/MiniPanTiltTeensy) project, which translate servo movement requests from the CameraVision app to actual servo movement against the [CameraMount](https://github.com/Team997Coders/2019DeepSpace/blob/vision/src/main/java/frc/robot/subsystems/CameraMount.java) subsystem. This subsystem is unique as it has been defined in the [SpartanLib](https://github.com/Team997Coders/SpartanLib/blob/master/cameramount/src/main/java/org/team997coders/spartanlib/subsystems/CameraMount.java) project and has been made generic through the use of interfaces to enable it to run on the embedded [Teensy](https://www.pjrc.com/store/teensy35.html) platform or the roborio. Note that in [build.gradle](https://github.com/Team997Coders/2019DeepSpace/blob/vision/build.gradle), there is a dependency reference to com.github.team997coders:SpartanLib:0.0.2-rc1. Through the magic of [Jitpack.io](https://jitpack.io/#Team997Coders/SpartanLib), references can be made directly to github from gradle and the package will automatically bundle (on jitpack's very cool site) and come down as part of the java plugin. GradleRio should automatically deploy the dependency. With Jitpack, you also get [javadocs](https://javadoc.jitpack.io/com/github/Team997Coders/SpartanLib/0.0.2-rc1/javadoc/index.html) for free! Here is some incentive to document your code.

Separately from this PR, Timothy has written code for CameraVision that writes targeting information into network tables, that can be used by an autonomous driving routine to control robot movement. See [NetworkTableWriter.java](https://github.com/Team997Coders/2019DSHatchFindingVision/blob/master/CameraVision/src/main/java/NetworkTableWriter.java). Hunter, it will be up to you or your designee to write the autonomous driving code.

Finally, CameraVision was set up to control servos by communicating to the teensy over a serial port. I have modified the application to optionally connect over network sockets to the roborio if the --nthost flag is set on the command line. [Mods](https://github.com/Team997Coders/2019DSHatchFindingVision/blob/roborio/CameraVision/src/main/java/Main.java) are in the roborio branch right now of CameraVision. It will need to be merged into the main branch, which I will probably do before the meeting today.

On a side note, the Teensy platform, as far as I can tell, has never run a Java application. I was able to adapt the [haiku](http://haiku-vm.sourceforge.net/) project, which uses the [lejos](https://lejos.sourceforge.io/) virtual machine, to transpile Java code to a native application, without an embedded OS, to run on the Teensy 3.5 Freescale 32 bit 120 MHz ARM Cortex-M4 CPU. I then built some [gradle tooling](https://github.com/chuckb/haikuVM) to make it easy to spin up an embedded project, that then can make use of the [wpilibj command scheduler](https://github.com/Team997Coders/WpilibjEmbedded). This enabled me to prototype the CameraMount subsystem, SlewCamera, SlewCameraToAngle,  CenterCamera, and associated custom protocols and integration test it with the CameraVision application without need for the roborio. Porting the necessary bits over to the roborio to eliminate the teensy from the mix took me some of Friday and Sunday.