### PR TITLE
Add autolock feature to vision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2019.3.2"
+    id "edu.wpi.first.GradleRIO" version "2019.4.1"
 }
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -163,6 +163,13 @@ public class Robot extends TimedRobot {
 
   @Override
   public void autonomousInit() {
+    cameraControlStateMachine.identifyTargets();
+
+    // NOTE: There must be a delay of AT LEAST 20ms to give
+    // the camera subsystem time to ingest some frames. The assumption
+    // is that autolock vision will be sandwiched between other commands,
+    // and so there should be no problem.
+
     // Get the autonomous chooser option
     AutonomousOptions autonomousOption = chooser.getSelected();
 
@@ -173,24 +180,26 @@ public class Robot extends TimedRobot {
       // should be logged...
       autonomousCommand = new AutoDoNothing();
     } else {
-      // TODO: Fill in these commands with the appropriate action
-      // The camera control state machine can do it, but more than left/right would have to be
-      // passed in.
+      // TODO: Fill in these commands with the appropriate actions.
+      // You can call cameraControlStateMachine.autoLockRight(), 
+      // cameraControlStateMachine.autoLockLeft(), or cameraControlStateMachine.autoLock()
+      // from your commands if you want to sandwich in vision autolocking after initial
+      // motion profile driving. Once initiated, then in a subsequent command to perform
+      // auto-drive based on vision feedback, use if (cameraControlStateMachine.getState() == CameraControlStateMachine.State.AutoLocked)
+      // conditional to determine if target is locked. Finally, use cameraControlStateMachine.getSelectedTarget() to get information
+      // about target. This function goes to network tables for you and gets the information about the lock on target
+      // as documented here: https://github.com/Team997Coders/2019DSHatchFindingVision/tree/master/CameraVision
       switch(autonomousOption) {
         case LeftCargoShip:
-          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Left);
           autonomousCommand = new AutoDoNothing();
           break;
         case RightCargoShip:
-          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Right);
           autonomousCommand = new AutoDoNothing();
           break;
         case LeftBottomRocket:
-          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Left);
           autonomousCommand = new AutoDoNothing();
           break;
         case RightBottomRocket:
-          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Right);
           autonomousCommand = new AutoDoNothing();
           break;
         case DoNothing:

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -69,7 +69,7 @@ public class Robot extends TimedRobot {
   public static LogitechVisionOI logitechVisionOI;
 
   Command autonomousCommand;
-  SendableChooser<Command> chooser = new SendableChooser<>();
+  SendableChooser<AutonomousOptions> chooser = new SendableChooser<>();
 
   public static int heightIndex;
   // used by the scoringHeight logic commands to grab the correct height from
@@ -122,8 +122,11 @@ public class Robot extends TimedRobot {
     pdp = new PowerDistributionPanel();
     pdp.clearStickyFaults();
 
-    chooser.setDefaultOption("Do Nothing", new AutoDoNothing());
-    // chooser.addOption("My Auto", new MyAutoCommand());
+    chooser.setDefaultOption("Do Nothing", AutonomousOptions.DoNothing);
+    chooser.addOption("Left Cargo Ship", AutonomousOptions.LeftCargoShip);
+    chooser.addOption("Right Cargo Ship", AutonomousOptions.RightCargoShip);
+    chooser.addOption("Left Bottom Rocket", AutonomousOptions.LeftBottomRocket);
+    chooser.addOption("Right Bottom Rocket", AutonomousOptions.RightBottomRocket);
     SmartDashboard.putData("Auto mode", chooser);
 
 
@@ -160,13 +163,42 @@ public class Robot extends TimedRobot {
 
   @Override
   public void autonomousInit() {
-    // Init hatch target finding vision camera
-    cameraControlStateMachine.identifyTargets();
-    autonomousCommand = chooser.getSelected();
+    // Get the autonomous chooser option
+    AutonomousOptions autonomousOption = chooser.getSelected();
 
-    if (autonomousCommand != null) {
-      autonomousCommand.start();
+    // An autonomous command must be set as a result of this activity
+
+    if (autonomousOption == null) {
+      // If it is null for some reason, do nothing. This should not happen and maybe
+      // should be logged...
+      autonomousCommand = new AutoDoNothing();
+    } else {
+      // TODO: Fill in these commands with the appropriate action
+      // The camera control state machine can do it, but more than left/right would have to be
+      // passed in.
+      switch(autonomousOption) {
+        case LeftCargoShip:
+          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Left);
+          autonomousCommand = new AutoDoNothing();
+          break;
+        case RightCargoShip:
+          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Right);
+          autonomousCommand = new AutoDoNothing();
+          break;
+        case LeftBottomRocket:
+          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Left);
+          autonomousCommand = new AutoDoNothing();
+          break;
+        case RightBottomRocket:
+          cameraControlStateMachine.autoLock(CameraControlStateMachine.ClosestToCenter.Right);
+          autonomousCommand = new AutoDoNothing();
+          break;
+        case DoNothing:
+          autonomousCommand = new AutoDoNothing();
+          break;
+      }
     }
+    autonomousCommand.start();
   }
 
   @Override
@@ -232,5 +264,9 @@ public class Robot extends TimedRobot {
 
     SmartDashboard.putNumber("Delta Time", kDeltaTime);
     SmartDashboard.putBoolean("Paths Loaded", PathManager.getInstance().loaded);
+  }
+
+  public enum AutonomousOptions {
+    LeftCargoShip, RightCargoShip, LeftBottomRocket, RightBottomRocket, DoNothing
   }
 }

--- a/src/main/java/frc/robot/commands/AutoDriveToTarget.java
+++ b/src/main/java/frc/robot/commands/AutoDriveToTarget.java
@@ -31,6 +31,7 @@ import frc.robot.RobotMap;
  */
 public class AutoDriveToTarget extends Command {
   private final DriveTrain driveTrain;
+  private final CameraControlStateMachine cameraControlStateMachine;
   private boolean weMadeIt;
 
   private double distSetpoint;
@@ -46,64 +47,67 @@ public class AutoDriveToTarget extends Command {
 	private double targetAngle;
 
   public AutoDriveToTarget() {
-    this(Robot.driveTrain);
+    this(Robot.driveTrain, Robot.cameraControlStateMachine);
   }
 
-  public AutoDriveToTarget(DriveTrain driveTrain) {
-    this.driveTrain = driveTrain;
+  public AutoDriveToTarget(DriveTrain driveTrain, CameraControlStateMachine cameraControStateMachine) {
+		this.driveTrain = driveTrain;
+		this.cameraControlStateMachine = cameraControStateMachine;
     requires(driveTrain);
   }
    
-    // Called just before this Command runs the first time
-    protected void initialize() {
-    	lastVoltage = 0;
-    	Robot.driveTrain.resetEncoders();
-    	Robot.driveTrain.setBrake();
-    	initYaw = Robot.driveTrain.getGyroAngle();
-    	this.previous_error = this.piderror();
-    	timer.reset();
-    	timer.start();
-		System.out.println("(PDTD-INIT) OMG, I got initialized!!! :O");
-		System.out.println("targetAngle: " + targetAngle);
-    	lastTime = 0;
-    }
+	// Called just before this Command runs the first time
+	protected void initialize() {
+		lastVoltage = 0;
+		// TODO: From CCB - just use driveTrain to make code testable
+		Robot.driveTrain.resetEncoders();
+		Robot.driveTrain.setBrake();
+		initYaw = Robot.driveTrain.getGyroAngle();
+		this.previous_error = this.piderror();
+		timer.reset();
+		timer.start();
+	System.out.println("(PDTD-INIT) OMG, I got initialized!!! :O");
+	System.out.println("targetAngle: " + targetAngle);
+		lastTime = 0;
+	}
     
-    // current algorithm assumes that we are starting
-    // from a stop
-    private double linearAccel(double input) {
-    	double Klin = 0.8;
-    	double deltaT = timer.get() - lastTime;
-    	lastTime = timer.get();
-    	
-    	double Volts = lastVoltage + Klin * (deltaT);
-    	if (Volts > input) {
-    		Volts = input;
-    	}
-    	lastVoltage = Volts;
-    	return Volts;
-    }
+	// current algorithm assumes that we are starting
+	// from a stop
+	private double linearAccel(double input) {
+		double Klin = 0.8;
+		double deltaT = timer.get() - lastTime;
+		lastTime = timer.get();
+		
+		double Volts = lastVoltage + Klin * (deltaT);
+		if (Volts > input) {
+			Volts = input;
+		}
+		lastVoltage = Volts;
+		return Volts;
+	}
 
     
-    public double pFactor() {
-    	// Calculate full PID
-    	// pfactor = (P × error) + (I × ∑error) + (D × δerrorδt)
-    	double error = this.piderror();
-    	// Integral is increased by the error*time (which is .02 seconds using normal IterativeRobot)
-    	this.integral += (error * .02);
-    	// Derivative is change in error over time
-    	double derivative = (error - this.previous_error) / .02;
-        this.previous_error = error;
-        return 
-        	(RobotMap.Values.driveDistanceP * error) + 
-        	(RobotMap.Values.driveDistanceI * this.integral) + 
-        	(RobotMap.Values.driveDistanceD * derivative);
-    }
+	public double pFactor() {
+		// Calculate full PID
+		// pfactor = (P × error) + (I × ∑error) + (D × δerrorδt)
+		double error = this.piderror();
+		// Integral is increased by the error*time (which is .02 seconds using normal IterativeRobot)
+		this.integral += (error * .02);
+		// Derivative is change in error over time
+		double derivative = (error - this.previous_error) / .02;
+			this.previous_error = error;
+			return 
+				(RobotMap.Values.driveDistanceP * error) + 
+				(RobotMap.Values.driveDistanceI * this.integral) + 
+				(RobotMap.Values.driveDistanceD * derivative);
+	}
     
-    // Called repeatedly when this Command is scheduled to run
-    protected void execute() {
-		// compute the pid P value
-		//System.out.println("Im driving");
+	// Called repeatedly when this Command is scheduled to run
+	protected void execute() {
+	// compute the pid P value
+	//System.out.println("Im driving");
 		try {
+			// TODO: From CCB - just use cameraControlStateMachine to make code testable
 			SelectedTarget selectedTarget = Robot.cameraControlStateMachine.getSelectedTarget();
 			distSetpoint = (selectedTarget.rangeInInches- 24) * (RobotMap.Values.protobotTickPerFoot/12) ;
 			targetAngle = selectedTarget.angleToTargetInDegrees;
@@ -112,87 +116,87 @@ public class AutoDriveToTarget extends Command {
 
 
 			/*
-			  selectedTarget contains: 
-			  rangeInInches
-			  cameraAngleInDegrees - camermount pan angle relative to robot, -90 to 90, with 0 being center
-			  angleToTargetInDegrees - robot's angle to target, from target's POV, -90 to 90, with 0 being perpenticular to target
+				selectedTarget contains: 
+				rangeInInches
+				cameraAngleInDegrees - camermount pan angle relative to robot, -90 to 90, with 0 being center
+				angleToTargetInDegrees - robot's angle to target, from target's POV, -90 to 90, with 0 being perpenticular to target
 			*/
-		  } catch (TargetNotLockedException e) {
+		} catch (TargetNotLockedException e) {
+			// TODO: From CCB - this variable is set and never used...what happens when lock is lost?
+			// Probably we just finish.
 			weMadeIt = false;
-		  }
-    	double pfactor = speed * Utils.clamp(this.pFactor(), -1, 1);
-    	double pfactor2 = linearAccel(pfactor);
-    	double deltaTheta = Robot.driveTrain.getGyroAngle() - initYaw;
-    	deltaT = timer.get() - lastTime;
-    	lastTime = timer.get();
+		}
+		double pfactor = speed * Utils.clamp(this.pFactor(), -1, 1);
+		double pfactor2 = linearAccel(pfactor);
+		double deltaTheta = Robot.driveTrain.getGyroAngle() - initYaw;
+		deltaT = timer.get() - lastTime;
+		lastTime = timer.get();
 
-    	// calculate yaw correction
-    	double yawcorrect = deltaTheta * Ktheta;
-    	
-    	// set the output voltage
-    	Robot.driveTrain.setVolts(-(pfactor2 + yawcorrect), -(pfactor2 - yawcorrect)); //TODO check these signs...
-    	//Robot.driveTrain.SetVoltssetVolts(-pfactor, -pfactor); //without yaw correction, accel
+		// calculate yaw correction
+		double yawcorrect = deltaTheta * Ktheta;
+		
+		// set the output voltage
+		Robot.driveTrain.setVolts(-(pfactor2 + yawcorrect), -(pfactor2 - yawcorrect)); //TODO check these signs...
+		//Robot.driveTrain.SetVoltssetVolts(-pfactor, -pfactor); //without yaw correction, accel
 
-    	// Debug information to be placed on the smart dashboard.
-    	SmartDashboard.putNumber("Setpoint", distSetpoint);
-    	SmartDashboard.putNumber("Encoder Distance", this.encoderDistance());
-    	//SmartDashboard.putNumber("Encoder Rate", Robot.driveTrain.getEncoderRate());
-    	SmartDashboard.putNumber("Distance Error", piderror());
-    	SmartDashboard.putNumber("K-P factor", pfactor);
-    	SmartDashboard.putNumber("K-P factor Accel", pfactor2);
-    	SmartDashboard.putNumber("deltaT", deltaT);
-    	SmartDashboard.putNumber("Theta Correction", yawcorrect);
-    	SmartDashboard.putBoolean("On Target", onTarget());
-    	SmartDashboard.putNumber("NavX Heading", Robot.driveTrain.getGyroAngle());
-    	SmartDashboard.putNumber("Init Yaw", initYaw);
-    }
+		// Debug information to be placed on the smart dashboard.
+		SmartDashboard.putNumber("Setpoint", distSetpoint);
+		SmartDashboard.putNumber("Encoder Distance", this.encoderDistance());
+		//SmartDashboard.putNumber("Encoder Rate", Robot.driveTrain.getEncoderRate());
+		SmartDashboard.putNumber("Distance Error", piderror());
+		SmartDashboard.putNumber("K-P factor", pfactor);
+		SmartDashboard.putNumber("K-P factor Accel", pfactor2);
+		SmartDashboard.putNumber("deltaT", deltaT);
+		SmartDashboard.putNumber("Theta Correction", yawcorrect);
+		SmartDashboard.putBoolean("On Target", onTarget());
+		SmartDashboard.putNumber("NavX Heading", Robot.driveTrain.getGyroAngle());
+		SmartDashboard.putNumber("Init Yaw", initYaw);
+	}
 
-    private double piderror() {
-    	// shouldn't we average this out between both of the encoders?
-    	return distSetpoint - this.encoderDistance();
-    }
-    
-    private double encoderDistance() {
-    	return (Robot.driveTrain.leftEncoderTicks() + Robot.driveTrain.rightEncoderTicks()) / 2;
-    }
-    
-    private boolean onTarget() {
-    	return piderror() < minError;
-    }
-    // Make this return true when this Command no longer needs to run execute()
-    protected boolean isFinished() {
-    	if (Robot.driveTrain.leftEncoderVelocity() <= 0 && 
-    			Robot.driveTrain.rightEncoderVelocity() <= 0 &&
-    			onTarget()) {
-    		System.out.println("(PDTD-ISFINISHED) PDTD ended with isFinished!");
-    		 return onTarget();
-    	} else {
-    		/*if (Robot.collector.getAvgLeftVoltage() > RobotMap.Values.autoIRthreshold ||
-    			Robot.collector.getAvgRightVoltage() > RobotMap.Values.autoIRthreshold) {
-    			return true;
-    		} else {
-    			return false;
-    		}*/
-    		return false;
-    	}
-    	
-    }
-    
-    // Called once after isFinished returns true
-    protected void end() {
-    	System.out.println(this.encoderDistance());
-    	System.out.println("PDrive End");
-    	timer.stop();
-    	Robot.driveTrain.setVolts(0, 0);
-    }
+	private double piderror() {
+		// shouldn't we average this out between both of the encoders?
+		return distSetpoint - this.encoderDistance();
+	}
+	
+	private double encoderDistance() {
+		return (Robot.driveTrain.leftEncoderTicks() + Robot.driveTrain.rightEncoderTicks()) / 2;
+	}
+	
+	private boolean onTarget() {
+		return piderror() < minError;
+	}
+	// Make this return true when this Command no longer needs to run execute()
+	protected boolean isFinished() {
+		// TODO: CCB - Also check the weMadeIt variable here in order to deal with lost lock
+		if (Robot.driveTrain.leftEncoderVelocity() <= 0 && 
+				Robot.driveTrain.rightEncoderVelocity() <= 0 &&
+				onTarget()) {
+			System.out.println("(PDTD-ISFINISHED) PDTD ended with isFinished!");
+				return onTarget();
+		} else {
+			/*if (Robot.collector.getAvgLeftVoltage() > RobotMap.Values.autoIRthreshold ||
+				Robot.collector.getAvgRightVoltage() > RobotMap.Values.autoIRthreshold) {
+				return true;
+			} else {
+				return false;
+			}*/
+			return false;
+		}
+		
+	}
+	
+	// Called once after isFinished returns true
+	protected void end() {
+		System.out.println(this.encoderDistance());
+		System.out.println("PDrive End");
+		timer.stop();
+		Robot.driveTrain.setVolts(0, 0);
+	}
 
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    protected void interrupted() {
-    	end();
-    	System.out.println("(PDTD-INTERRUPTED) I got interrupted!! D:");
-    }
-  }
-  
-
-  
+	// Called when another command which requires one or more of the same
+	// subsystems is scheduled to run
+	protected void interrupted() {
+		end();
+		System.out.println("(PDTD-INTERRUPTED) I got interrupted!! D:");
+	}
+}

--- a/src/main/java/frc/robot/commands/ControlCamera.java
+++ b/src/main/java/frc/robot/commands/ControlCamera.java
@@ -9,6 +9,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;
 import frc.robot.buttonbox.ButtonBox;
@@ -30,6 +31,7 @@ public class ControlCamera extends Command {
   private final MiniPID pidY;
   private final double lockThresholdFactor;
   private final ButtonBox buttonBox;
+  private final NetworkTable smartDashboard;
 
   /**
    * Default constructor to be used as the default command
@@ -44,7 +46,9 @@ public class ControlCamera extends Command {
       Robot.visionNetworkTable, 
       new MiniPID(0.25, 0, 0), 
       new MiniPID(0.25, 0, 0),
-      0.05);
+      0.05,
+      NetworkTableInstance.getDefault().getTable("SmartDashboard")
+      );
   }
 
   /**
@@ -69,7 +73,8 @@ public class ControlCamera extends Command {
       NetworkTable visionNetworkTable,
       MiniPID pidX,
       MiniPID pidY,
-      double lockThresholdFactor) {
+      double lockThresholdFactor,
+      NetworkTable smartDashboard) {
     this.scoringDirection = scoringDirection;
     this.buttonBox = buttonBox;
     this.cameraControlStateMachine = cameraControlStateMachine;
@@ -77,6 +82,7 @@ public class ControlCamera extends Command {
     this.pidX = pidX;
     this.pidY = pidY;
     this.lockThresholdFactor = lockThresholdFactor;
+    this.smartDashboard = smartDashboard;
     if (scoringDirection == ButtonBox.ScoringDirectionStates.Front) {
       this.cameraMount = frontCameraMount;
     } else if (scoringDirection == ButtonBox.ScoringDirectionStates.Back) {
@@ -168,6 +174,8 @@ public class ControlCamera extends Command {
     // slew based on PID values related to how close we are to slewpoint
     double panRate = pidX.getOutput(selectedTarget.normalizedPointFromCenter.x);
     double tiltRate = pidY.getOutput(selectedTarget.normalizedPointFromCenter.y) * -1.0;
+    smartDashboard.getEntry("Camera Control panRate").setDouble(panRate);
+    smartDashboard.getEntry("Camera Control tiltRate").setDouble(tiltRate);
     cameraMount.slew(panRate, tiltRate);
   }
 

--- a/src/main/java/frc/robot/commands/ControlCamera.java
+++ b/src/main/java/frc/robot/commands/ControlCamera.java
@@ -142,7 +142,8 @@ public class ControlCamera extends Command {
         }
       // Keep the camera in the center of FOV under automated control.
       } else if (cameraControlStateMachine.getState() == CameraControlStateMachine.State.TargetLocked || 
-          cameraControlStateMachine.getState() == CameraControlStateMachine.State.DrivingToTarget) {
+                cameraControlStateMachine.getState() == CameraControlStateMachine.State.AutoLocked ||
+                cameraControlStateMachine.getState() == CameraControlStateMachine.State.DrivingToTarget) {
         // Get the selected target to process
         SelectedTarget selectedTarget = new SelectedTarget(visionNetworkTable);
         // Follow it

--- a/src/main/java/frc/robot/vision/CameraControlStateMachine.java
+++ b/src/main/java/frc/robot/vision/CameraControlStateMachine.java
@@ -304,11 +304,11 @@ public class CameraControlStateMachine {
           visionNetworkTable.getEntry(CameraControlStateMachine.TRIGGERKEY).getString("");          
         }
       })
-      .ignore(Trigger.BButton, State.DrivingToTarget)
-      .ignore(Trigger.AButton, State.IdentifyingTargets)
-      .ignore(Trigger.IdentifyTargets, State.IdentifyingTargets)
-      .ignore(Trigger.LoseLock, State.LockLost)
-      .ignore(Trigger.Slew)
+      .permit(Trigger.Slew, State.AutoLocking)
+      .ignore(Trigger.BButton)
+      .ignore(Trigger.AButton)
+      .ignore(Trigger.IdentifyTargets)
+      .ignore(Trigger.LoseLock)
       .ignore(Trigger.LeftThumbstickButton)
       .ignore(Trigger.XButton)
       .ignore(Trigger.YButton)

--- a/src/main/java/frc/robot/vision/CameraControlStateMachine.java
+++ b/src/main/java/frc/robot/vision/CameraControlStateMachine.java
@@ -285,7 +285,7 @@ public class CameraControlStateMachine {
     config.configure(State.Calibrating)
       .onEntry(new Action1<Transition<State,Trigger>>() {
         public void doIt(Transition<State, Trigger> transition) {
-          visionNetworkTable.getEntry(STATEKEY).setString(State.Calibrating.toString());
+          visionNetworkTable.getEntry(CameraControlStateMachine.STATEKEY).setString(State.Calibrating.toString());
           visionNetworkTable.getEntry(CameraControlStateMachine.TRIGGERKEY).setString("");
       }})
       .permit(Trigger.AButton, State.IdentifyingTargets)
@@ -297,8 +297,25 @@ public class CameraControlStateMachine {
       .ignore(Trigger.XButton)
       .ignore(Trigger.YButton);
 
+    config.configure(State.AutoLocking)
+      .onEntry(new Action1<Transition<State,Trigger>>() {
+        public void doIt(Transition<State, Trigger> transition){
+          visionNetworkTable.getEntry(CameraControlStateMachine.STATEKEY).setString(State.Calibrating.toString());
+          visionNetworkTable.getEntry(CameraControlStateMachine.TRIGGERKEY).getString("");          
+        }
+      })
+      .ignore(Trigger.BButton, State.DrivingToTarget)
+      .ignore(Trigger.AButton, State.IdentifyingTargets)
+      .ignore(Trigger.IdentifyTargets, State.IdentifyingTargets)
+      .ignore(Trigger.LoseLock, State.LockLost)
+      .ignore(Trigger.Slew)
+      .ignore(Trigger.LeftThumbstickButton)
+      .ignore(Trigger.XButton)
+      .ignore(Trigger.YButton)
+      .ignore(Trigger.LeftShoulderButton);
     return config;
   }
+  
 
   public void aButtonPressed() {
     stateMachine.fire(Trigger.AButton);
@@ -402,7 +419,7 @@ public class CameraControlStateMachine {
    * The valid states of the state machine.
    */
   public enum State {
-    IdentifyingTargets, SlewingToTarget, TargetLocked, LockFailed, LockLost, DrivingToTarget, Slewing, Centering, Calibrating
+    IdentifyingTargets, SlewingToTarget, TargetLocked, LockFailed, LockLost, DrivingToTarget, Slewing, Centering, Calibrating, AutoLocking
   }
 
   /**


### PR DESCRIPTION
You can call cameraControlStateMachine.autoLockRight(), cameraControlStateMachine.autoLockLeft(), or cameraControlStateMachine.autoLock() from your commands if you want to sandwich in vision autolocking after initial motion profile driving. Once initiated, then in a subsequent command to perform auto-drive based on vision feedback, use if (cameraControlStateMachine.getState() == CameraControlStateMachine.State.AutoLocked) conditional to determine if target is locked. Finally, use cameraControlStateMachine.getSelectedTarget() to get information about target. This function goes to network tables for you and gets the information about the lock on target as documented here: https://github.com/Team997Coders/2019DSHatchFindingVision/tree/master/CameraVision
